### PR TITLE
Update Android SDK and support libraries to 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,31 +2,32 @@ apply plugin: 'com.android.application'
 //apply from: '../deps.gradle'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         applicationId 'net.alhazmy13.mediapickerexample'
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     lintOptions {
         abortOnError false
     }
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:27.1.0"
-    implementation "com.android.support:design:27.1.0"
-    implementation "com.android.support:support-v13:27.1.0"
+    implementation "com.android.support:appcompat-v7:28.0.0"
+    implementation "com.android.support:design:28.0.0"
+    implementation "com.android.support:support-v13:28.0.0"
     implementation project(':libary')
     implementation project(':rxjava')
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,16 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
-        google()
+
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
         classpath 'com.novoda:bintray-release:0.8.0'
     }
 }

--- a/libary/build.gradle
+++ b/libary/build.gradle
@@ -14,26 +14,24 @@ publish {
 }
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
+
     lintOptions {
         abortOnError false
     }
-
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-
     }
 }
 

--- a/rxjava/build.gradle
+++ b/rxjava/build.gradle
@@ -15,15 +15,15 @@ apply plugin: 'com.android.library'
 //}
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Requires to update the Android Gradle plugin to version 3.3.2 as well. No need to specify the build tools version explicitly as the Android Gradle plugin requests it by default. With plugin 3.3.2, build-tools 28.0.3 is the lower boundary.